### PR TITLE
Add and adjust Drush milestones

### DIFF
--- a/drupal-timeline.json
+++ b/drupal-timeline.json
@@ -56,6 +56,14 @@
     "comment": ""
   },
   {
+    "priority": 3,
+    "date": "2010-04-22T00:00:00+00:00",
+    "title": "Drush site aliases added in 3.0 release",
+    "href": "https://www.drupal.org/project/drush/releases/6.x-3.0",
+    "description": "Site aliases provide a way to keep track of and manage remote Drupal sites, making it easy to copy databases from one site to another with the sql-sync command.",
+    "comment": ""
+  },
+  {
     "priority": 2,
     "date": "2010-02-05T00:00:00+00:00",
     "title": "Drupal development moves from CVS to Git",
@@ -73,10 +81,10 @@
   },
   {
     "priority": 3,
-    "date": "2009-01-16T00:00:00+00:00",
-    "title": "Drush 3 is released",
-    "href": "https://www.drupal.org/project/drush/releases/5.x-2.0-alpha2",
-    "description": "Drush is no longer a module, leading to lots of functionality and popularity. Drush becomes the de facto command line tool for Drupal.",
+    "date": "2009-06-09T00:00:00+00:00",
+    "title": "Drush becomes stand-alone tool with 2.0 release",
+    "href": "https://www.drupal.org/project/drush/releases/6.x-2.0",
+    "description": "Drush is no longer a module, leading to lots of functionality and popularity.",
     "comment": ""
   },
   {
@@ -85,6 +93,14 @@
     "title": "Drupal 6.0 released",
     "href": "",
     "description": "This release features a rewritten menu system, and an Update Status module which prompts admins to update their modules, especially after a security release.",
+    "comment": ""
+  },
+  {
+    "priority": 3,
+    "date": "2008-02-11T00:00:00+00:00",
+    "title": "Drush 1.0 released",
+    "href": "https://www.drupal.org/project/drush/releases/5.x-1.0",
+    "description": "Promising 'More Beer, Less Effort', Drush becomes the de facto command line tool for Drupal, streamlining the module installation process and making it much easier to 'Keep Calm and Clear the Cache.'",
     "comment": ""
   },
   {
@@ -220,7 +236,7 @@
     "date": "2001-01-15T00:00:00+00:00",
     "title": "Drupal 1.0 is released",
     "href": "",
-    "description": "Dries Buytaert shares the initial release of his 'dormitory bulletin board'. It includes 18 files that are called modules. It features a hook system where modules interact with each other and the core framework. On this very day, Wikipedia is also born. Had that happened 6 months later, it would probably be a Drupal site!.",
+    "description": "Dries Buytaert shares the initial release of his 'dormitory bulletin board'. Drupal is modular from the start. It includes 18 files that are called modules. It features a hook system where modules interact with each other and the core framework. On this very day, Wikipedia is also born!.",
     "comment": ""
   }
 ]


### PR DESCRIPTION
The Drush 2 release was advertised as the Drush 3 release; fixed that and switched the date from the alpha to the stable release data. Also added significant Drush milestones like 1.0 and 3.0 (site aliases)

We could put the Drush 2 date back to alpha2 instead of stable if you want (the 2.0 and 3.0 releases are really close together), but the other milestones by and by large are the stable release.

Other milestones we could consider (I figured these might not make the cut, but could consider adding maybe 9 or something):

Drush 5 (23 March 2012): Drush make added to Drush core
Drush 6 (Aug 17, 2013): Output formats introduced, Drush moves to GitHub
Drush 7 (May 20, 2015): PHP REPL
Drush 8 (Nov 19, 2015): Install Drush with Composer
Drush 9 (Jan 24, 2018): Drupal Code Generator, Drush uses Symfony Console
Drush 10 (Oct 31, 2019): Deprecations removed
